### PR TITLE
Check that a package exists

### DIFF
--- a/lib/npm-exists.js
+++ b/lib/npm-exists.js
@@ -1,0 +1,11 @@
+module.exports = function npmExists(module) {
+    return new Promise((resolve, reject) => {
+        if (this.constructor.name !== 'EventEmitter') {
+            const error = new TypeError(`'npmExists' must be call on an NPM instance (EventEmitter), was called on ${this.constructor.name}`);
+            reject(error);
+            return;
+        }
+
+        this.view(module, 'name', (error, result) => resolve(!error));
+    });
+};

--- a/lib/npm-publish.js
+++ b/lib/npm-publish.js
@@ -2,7 +2,8 @@ module.exports = function npmPublish() {
     return new Promise((resolve, reject) => {
         if (this.constructor.name !== 'EventEmitter') {
             const error = new TypeError(`'npmPublish' must be call on an NPM instance (EventEmitter), was called on ${this.constructor.name}`);
-            reject();
+            reject(error);
+            return;
         }
 
         this.publish((error, result) => {

--- a/lib/npm-set-tag.js
+++ b/lib/npm-set-tag.js
@@ -2,7 +2,8 @@ module.exports = function npmSetTag(module, tag) {
     return new Promise((resolve, reject) => {
         if (this.constructor.name !== 'EventEmitter') {
             const error = new TypeError(`'npmSetTag' must be call on an NPM instance (EventEmitter), was called on ${this.constructor.name}`);
-            reject();
+            reject(error);
+            return;
         }
 
         this.distTag('set', module, tag, (error, result) => {

--- a/lib/npm-view-version.js
+++ b/lib/npm-view-version.js
@@ -2,7 +2,8 @@ module.exports = function npmViewVersion(module) {
     return new Promise((resolve, reject) => {
         if (this.constructor.name !== 'EventEmitter') {
             const error = new TypeError(`'npmViewVersion' must be call on an NPM instance (EventEmitter), was called on ${this.constructor.name}`);
-            reject();
+            reject(error);
+            return;
         }
 
         this.view(module, 'version', (error, result) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ndsh",
-  "version": "1.2.0",
+  "version": "1.2.1-rc.0",
   "author": "Fiverr SRE",
   "description": "NPX runner for shell scripts",
   "repository": {

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -39,13 +39,16 @@ module.exports = (testing = '') => new Promise((resolve, reject) => {
                 tag = branch;
             }
 
+            const npmExists = require('../lib/npm-exists');
+            const exists = await npmExists.call(instance, name);
+
             const npmViewVersion = require('../lib/npm-view-version');
-            const published = await npmViewVersion.call(instance, `${name}@${version}`) === version;
-            const released = await npmViewVersion.call(instance, `${name}@${tag}`) === version;
+            const published = exists && await npmViewVersion.call(instance, `${name}@${version}`) === version;
+            const released = exists && await npmViewVersion.call(instance, `${name}@${tag}`) === version;
 
             // Version not published yet - let's publish it
             if (!published) {
-                const message = `Publish version ${version.underline} to tag ${tag.underline}`;
+                const message = `${exists ? '' : `${name} package doesn't exist yet. `}Publish version ${version.underline} to tag ${tag.underline}`;
 
                 if (isTest) {
                     resolve(message);


### PR DESCRIPTION
Address issue #3
> # npm publish can't find package
>
> during initial setup of a repo, we haven't `npm publish` a package at all and it seems that the publish script try to fetch data on the package that we haven't publish yet at all.
> 
> https://github.com/fiverr/ndsh/blob/master/scripts/publish.js#L43
> 
> example:
> 1. dev create a repo, with a package - that was never publish at all and doesn't exists in the registry.
> 2. our publish script try to fetch data on the specific package and fail(because it was never published) - see below:
> ```
> #!/bin/bash -eo pipefail
> npx ndsh publish
> npx: installed 483 in 14.592s
> { Error: Not found : @<package_Name>
>     at makeError 
> ```